### PR TITLE
Added the set navigation header to posts included in offline sets

### DIFF
--- a/classes/postSet.js
+++ b/classes/postSet.js
@@ -75,4 +75,19 @@ class PostSet {
         this._customSetStorageInstance.deleteSet(this.getId());
     }
 
+    getPostIndexInSet(postId) {
+        if (!postId)
+            throw Error("No post ID was passed!");
+
+        return this._posts.findIndex(post => post.postId === postId);
+    }
+
+    getPostByIndex(index) {
+        return this._posts[index];
+    }
+
+    getPostCount() {
+        return this._posts.length;
+    }
+
 }

--- a/classes/userSets.js
+++ b/classes/userSets.js
@@ -49,4 +49,11 @@ class UserSets {
         }
     }
 
+    getSetsOfPost(postId) {
+        if (!postId)
+            throw Error("No post ID was passed!");
+
+        return this._setInstances.filter(set => set.getPostIndexInSet(postId) !== -1);
+    }
+
 }

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -18,14 +18,13 @@ class PostController {
     }
 
     #displayPostSets() {
-        const noSetQueryNavigator = document.querySelector("#nav-links-top > div.search-seq-nav");
         const queriedSetId = new URLSearchParams(document.location.search).get("custom_set_id");
 
         const sets = new UserSets(UserHelper.getCurrentUserId()).getSetsOfPost(this.#getCurrentPostId());
         if (sets.length === 0)
             return;
 
-        noSetQueryNavigator.style.display = "none";
+        this.#replaceSetQueryNavigator();
 
         const setNavBar = this.#getSetNavBar();
         sets.forEach(setInstance => {
@@ -37,6 +36,12 @@ class PostController {
                 setNavBar.appendChild(setNavElement);
             }
         });
+    }
+
+    #replaceSetQueryNavigator() {
+        //Simply hide the set query for now because it can be very complicated especially when combining multiple offline sets
+        const noSetQueryNavigator = document.querySelector("#nav-links-top > div.search-seq-nav");
+        noSetQueryNavigator.style.display = "none";
     }
 
     #createSetNavElement(setInstance) {


### PR DESCRIPTION
Just like the standard e6 sets, the set navigation element will now be displayed for posts that are included in an offline set:
![image](https://github.com/S87GMIL/e621_unlimited_sets/assets/63162984/532a9524-5d81-413d-a1fa-80a284b6dcb7)
